### PR TITLE
fix(plots): Convert default width and height to pixels

### DIFF
--- a/R/dataProcessPlotsLiP.R
+++ b/R/dataProcessPlotsLiP.R
@@ -36,8 +36,8 @@
 #' @param dot.size.profile size of dots in Profile plot. Default is 2.
 #' @param ncol.guide number of columns for legends at the top of plot. Default
 #' is 5.
-#' @param width width of the saved pdf file. Default is 10.
-#' @param height height of the saved pdf file. Default is 10.
+#' @param width width of the saved pdf file. Default is 800 pixels.
+#' @param height height of the saved pdf file. Default is 600 pixels.
 #' @param lip.title title of all LiP QC plot
 #' @param protein.title title of all Protein QC plot
 #' @param which.Peptide LiP peptide list to draw plots. List can be names of
@@ -83,8 +83,8 @@ dataProcessPlotsLiP <- function(data,
                                 legend.size = 7,
                                 dot.size.profile = 2,
                                 ncol.guide = 5,
-                                width = 10,
-                                height = 12,
+                                width = 800,
+                                height = 600,
                                 lip.title = "All Peptides",
                                 protein.title = "All Proteins",
                                 which.Peptide = "all",

--- a/R/groupComparisonPlotsLiP.R
+++ b/R/groupComparisonPlotsLiP.R
@@ -55,8 +55,8 @@
 #' @param colorkey TRUE(default) shows colorkey.
 #' @param numProtein The number of proteins which will be presented in each
 #' heatmap. Default is 50.
-#' @param width width of the saved file. Default is 10.
-#' @param height height of the saved file. Default is 10.
+#' @param width width of the saved file. Default is 800 pixels.
+#' @param height height of the saved file. Default is 600 pixels.
 #' @param which.Comparison list of comparisons to draw plots. List can be
 #' labels of comparisons or order numbers of comparisons from levels(data$Label)
 #' , such as levels(testResultMultiComparisons$ComparisonResult$Label).
@@ -105,8 +105,8 @@ groupComparisonPlotsLiP <- function(data = data,
                                     ProteinName=TRUE,
                                     colorkey=TRUE,
                                     numProtein=100,
-                                    width=10,
-                                    height=10,
+                                    width=800,
+                                    height=600,
                                     which.Comparison="all",
                                     which.Peptide="all",
                                     which.Protein=NULL,

--- a/man/dataProcessPlotsLiP.Rd
+++ b/man/dataProcessPlotsLiP.Rd
@@ -16,8 +16,8 @@ dataProcessPlotsLiP(
   legend.size = 7,
   dot.size.profile = 2,
   ncol.guide = 5,
-  width = 10,
-  height = 12,
+  width = 800,
+  height = 600,
   lip.title = "All Peptides",
   protein.title = "All Proteins",
   which.Peptide = "all",
@@ -62,9 +62,9 @@ Profile plot and QC plot. Default is 0.}
 \item{ncol.guide}{number of columns for legends at the top of plot. Default
 is 5.}
 
-\item{width}{width of the saved pdf file. Default is 10.}
+\item{width}{width of the saved pdf file. Default is 800 pixels.}
 
-\item{height}{height of the saved pdf file. Default is 10.}
+\item{height}{height of the saved pdf file. Default is 600 pixels.}
 
 \item{lip.title}{title of all LiP QC plot}
 

--- a/man/groupComparisonPlotsLiP.Rd
+++ b/man/groupComparisonPlotsLiP.Rd
@@ -22,8 +22,8 @@ groupComparisonPlotsLiP(
   ProteinName = TRUE,
   colorkey = TRUE,
   numProtein = 100,
-  width = 10,
-  height = 10,
+  width = 800,
+  height = 600,
   which.Comparison = "all",
   which.Peptide = "all",
   which.Protein = NULL,
@@ -90,9 +90,9 @@ displayed next to the points. FALSE means no protein names are displayed.}
 \item{numProtein}{The number of proteins which will be presented in each
 heatmap. Default is 50.}
 
-\item{width}{width of the saved file. Default is 10.}
+\item{width}{width of the saved file. Default is 800 pixels.}
 
-\item{height}{height of the saved file. Default is 10.}
+\item{height}{height of the saved file. Default is 600 pixels.}
 
 \item{which.Comparison}{list of comparisons to draw plots. List can be
 labels of comparisons or order numbers of comparisons from levels(data$Label)


### PR DESCRIPTION
## Dependent on PTM changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Plot exports for LiP workflows now default to 800x600 pixels, replacing previous inch-based defaults. This provides more consistent on-screen and file output sizing across processing and group comparison plots.
  - Improved consistency of default dimensions across plotting outputs to reduce manual resizing.

- Documentation
  - Help pages updated to reflect the new pixel-based width/height defaults (800x600) and clarify units.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->