### PR TITLE
tests(pcaPlot): Add barwidth to pcaplot to remove warnings

### DIFF
--- a/R/PCAPlotLiP.R
+++ b/R/PCAPlotLiP.R
@@ -290,7 +290,8 @@ pca.component.bar.plot <- function(data, n.components, title){
     main = title,
     xlab = "PC",
     ylab = "Variance",
-    ggtheme = theme_minimal())
+    ggtheme = theme_minimal(),
+    bar_width = 1)
   )
   
   return(temp.bar.plot)


### PR DESCRIPTION
Getting build errors https://bioconductor.org/checkResults/devel/bioc-LATEST/MSstatsLiP/

One of the fixes needed is due to an error message

```
Warning message:
In geom_bar(stat = "identity", fill = barfill, color = barcolor,  :
  Ignoring empty aesthetic: `width`.
```

We needed to pass bar_width to one of our dependencies

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Style
  - Updated the PCA explained-variance bar plot to use a fixed bar width for consistent visual proportions.
  - Switched the plot to a minimal theme for a cleaner, more readable presentation.
  - Visual-only changes; analysis results, parameters, and workflows remain unchanged.
  - No changes to public APIs or function signatures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->