### PR TITLE
Fix build

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: MSstatsLiP
 Title: LiP Significance Analysis in shotgun mass spectrometry-based proteomic experiments
-Version: 1.17.0
+Version: 1.17.1
 Date: 2024-3-19
 Description: Tools for LiP peptide and protein significance analysis. Provides 
               functions for summarization, estimation of LiP peptide abundance, 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -31,4 +31,4 @@ BugReports: https://github.com/Vitek-Lab/MSstatsLiP/issues
 Encoding: UTF-8
 LazyData: TRUE
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.3.2
+RoxygenNote: 7.3.3

--- a/R/groupComparisonLiP.R
+++ b/R/groupComparisonLiP.R
@@ -13,23 +13,15 @@
 #' @param data list of summarized datasets. Can be output of MSstatsLiP
 #' summarization function \code{\link[MSstatsLiP]{dataSummarizationLiP}}. Must
 #' include dataset named "LiP" as minimum.
-#' @param contrast.matrix comparison between conditions of interests. Default
-#' models full pairwise comparison between all conditions
 #' @param fasta.path a file path to a fasta file that includes the proteins
 #' listed in the data. Default is NULL. Include this parameter to determine
 #' trypticity of peptides in LiP models.
-#' @param log_base base of the logarithm used in dataProcess.
-#' @param use_log_file logical. If TRUE, information about data processing
-#' will be saved to a file.
-#' @param append logical. If TRUE, information about data processing will be
-#' added to an existing log file.
-#' @param verbose logical. If TRUE, information about data processing will be
-#' printed to the console.
 #' @param log_file_path character. Path to a file to which information about
 #' data processing will be saved.
 #' If not provided, such a file will be created automatically.
 #' If `append = TRUE`, has to be a valid path to a file.
 #' @param base start of the file name.
+#' @inheritParams MSstatsPTM::groupComparisonPTM
 #' @return list of modeling results. Includes LiP, PROTEIN, and ADJUSTED LiP
 #'         data.tables with their corresponding model results.
 #' @examples
@@ -92,9 +84,20 @@ groupComparisonLiP <- function(data, contrast.matrix = "pairwise",
                       PROTEIN = data.protein)
 
   ## Model
-  model.data <- groupComparisonPTM(format.data, "LabelFree", contrast.matrix,
-                                   FALSE, "BH", log_base, use_log_file, append,
-                                   verbose, path, base)
+  model.data <- groupComparisonPTM(
+      format.data, 
+      contrast.matrix = contrast.matrix,
+      ptm_label_type = "LF",
+      protein_label_type = "LF",
+      moderated = FALSE, 
+      adj.method = "BH",
+      log_base = log_base,
+      save_fitted_models=TRUE,
+      use_log_file = use_log_file, 
+      append = append,
+      verbose = verbose, 
+      log_file_path = path
+  )
   model.data$ADJUSTED.Model <- model.data$ADJUSTED.Model[!is.na(
     model.data$ADJUSTED.Model$Protein)]
 

--- a/man/groupComparisonLiP.Rd
+++ b/man/groupComparisonLiP.Rd
@@ -29,7 +29,8 @@ models full pairwise comparison between all conditions}
 listed in the data. Default is NULL. Include this parameter to determine
 trypticity of peptides in LiP models.}
 
-\item{log_base}{base of the logarithm used in dataProcess.}
+\item{log_base}{For non-TMT experiments only. The base of the logarithm used
+in summarization.}
 
 \item{use_log_file}{logical. If TRUE, information about data processing
 will be saved to a file.}


### PR DESCRIPTION
# Motivation and Context

Please include relevant motivation and context of the problem along with a short summary of the solution.

## Changes

Please provide a detailed bullet point list of your changes.

- 

## Testing

Please describe any unit tests you added or modified to verify your changes.

## Checklist Before Requesting a Review
- [ ] I have read the MSstats [contributing guidelines](https://github.com/Vitek-Lab/MSstatsConvert/blob/master/.github/CONTRIBUTING.md)
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have run the devtools::document() command after my changes and committed the added files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Motivation and Context

This PR fixes a critical build issue related to how `msstatsLiP` invokes the `groupComparisonPTM` function from the MSstatsPTM package. The previous invocation used positional arguments which could lead to parameter misalignment or compatibility issues with the upstream MSstatsPTM package. By refactoring the call to use explicit named parameters, the code becomes more maintainable and compatible with the MSstatsPTM API contract.

## Changes

- **Package Version Update**: Bumped version from 1.17.0 to 1.17.1 in DESCRIPTION file
- **RoxygenNote Update**: Incremented RoxygenNote from 7.3.2 to 7.3.3 in DESCRIPTION file
- **Refactored `groupComparisonPTM` Invocation** in `R/groupComparisonLiP.R` (lines 87-100):
  - Changed from positional argument form to fully named parameter form
  - Explicitly specified `ptm_label_type = "LF"` and `protein_label_type = "LF"` parameters
  - Added explicit `moderated = FALSE` and `adj.method = "BH"` parameters
  - Retained and properly mapped `log_base` parameter
  - Added explicit `save_fitted_models = TRUE` parameter to preserve fitted model objects
  - Renamed and mapped `path` variable to `log_file_path` parameter for clarity
  - Maintained existing log file control parameters: `use_log_file`, `append`, `verbose`
- **Documentation Updates** in `R/groupComparisonLiP.R`:
  - Added `@inheritParams MSstatsPTM::groupComparisonPTM` to inherit parameter documentation from the upstream package
- **Documentation Updates** in `man/groupComparisonLiP.Rd`:
  - Clarified `log_base` parameter description to specify it applies only to non-TMT experiments
  - Updated description to define its role as "the base of the logarithm used in summarization"
- **No API Changes**: The public function signature of `groupComparisonLiP` remains unchanged; only internal implementation details were modified

## Testing

The existing comprehensive test suite in `inst/tinytest/test_groupComparisonLiP.R` validates the functionality:
- Tests for error handling with missing or invalid input data (null LiP data raises error; null TrP data is allowed)
- Tests verify silent execution with valid input data
- Tests confirm function returns a list with expected structure containing `LiP.Model`, `TrP.Model`, and `Adjusted.LiP.Model` as data.tables
- Tests validate expected column names in each returned model output:
  - `LiP.Model`: FULL_PEPTIDE, Label, log2FC, SE, Tvalue, DF, pvalue, adj.pvalue, issue, MissingPercentage, ImputationPercentage, ProteinName, PeptideSequence
  - `TrP.Model`: Protein, Label, log2FC, SE, Tvalue, DF, pvalue, adj.pvalue, issue, MissingPercentage, ImputationPercentage
  - `Adjusted.LiP.Model`: FULL_PEPTIDE, Label, log2FC, SE, Tvalue, DF, pvalue, adj.pvalue, GlobalProtein, Adjusted, ProteinName, PeptideSequence, issue
- No new tests were added for this PR; existing tests remain unchanged and functional

## Coding Guidelines

No coding guideline violations were detected. The refactoring to use named parameters is a best practice that improves code maintainability and reduces the risk of argument ordering errors when interfacing with external package functions. This change aligns with R package development best practices for calling functions with multiple parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->