### PR TITLE
refactor(groupComparisonLiP): Use ptm_label_type and protein_label_type for groupComparisonPTM dependency

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: MSstatsLiP
 Title: LiP Significance Analysis in shotgun mass spectrometry-based proteomic experiments
-Version: 1.17.0
+Version: 1.17.1
 Date: 2024-3-19
 Description: Tools for LiP peptide and protein significance analysis. Provides 
               functions for summarization, estimation of LiP peptide abundance, 
@@ -20,7 +20,7 @@ Authors@R: c(person("Devon", "Kohler", email = "kohler.d@northeastern.edu", role
 License: Artistic-2.0
 Depends: R (>= 4.1)
 Imports: dplyr, gridExtra, stringr, ggplot2, grDevices, MSstats, MSstatsConvert,
-          data.table, Biostrings, MSstatsPTM, Rcpp, checkmate, factoextra, 
+          data.table, Biostrings, MSstatsPTM (>= 2.12.0), Rcpp, checkmate, factoextra, 
           ggpubr, purrr, tibble, tidyr, tidyverse, scales, stats, plotly, htmltools
 Suggests: BiocStyle, knitr, rmarkdown, covr, tinytest, gghighlight
 LinkingTo: Rcpp

--- a/R/groupComparisonLiP.R
+++ b/R/groupComparisonLiP.R
@@ -92,9 +92,20 @@ groupComparisonLiP <- function(data, contrast.matrix = "pairwise",
                       PROTEIN = data.protein)
 
   ## Model
-  model.data <- groupComparisonPTM(format.data, "LabelFree", contrast.matrix,
-                                   FALSE, "BH", log_base, use_log_file, append,
-                                   verbose, path, base)
+  model.data <- groupComparisonPTM(
+      format.data, 
+      ptm_label_type = "LF", 
+      protein_label_type = "LF",
+      contrast.matrix = contrast.matrix,
+      moderated = FALSE, 
+      adj.method = "BH", 
+      log_base = log_base, 
+      use_log_file = use_log_file, 
+      append = append,
+      verbose = verbose, 
+      log_file_path = path, 
+      base = base
+  )
   model.data$ADJUSTED.Model <- model.data$ADJUSTED.Model[!is.na(
     model.data$ADJUSTED.Model$Protein)]
 


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Motivation and Context

The refactor makes the internal call from groupComparisonLiP to MSstatsPTM::groupComparisonPTM explicit and more maintainable by passing all parameters as named arguments and by specifying label types for PTM and protein data. This clarifies that both PTM and protein data are label-free (ptm_label_type = "LF", protein_label_type = "LF") and reduces reliance on positional argument ordering when delegating to groupComparisonPTM.

## Detailed Changes

- R/groupComparisonLiP.R
  - Replaced a prior positional-style call to groupComparisonPTM with an explicit named-argument call.
  - Added ptm_label_type = "LF" and protein_label_type = "LF" to the groupComparisonPTM call.
  - Passed contrast.matrix via contrast.matrix = contrast.matrix.
  - Set moderated = FALSE and adj.method = "BH" explicitly in the call.
  - Converted log-related parameters to named arguments in the call: log_base, use_log_file, append, verbose, log_file_path (uses computed path variable), base.
  - Kept existing upstream formatting, lookup_table construction, tryptic labeling, and result post-processing logic unchanged.
  - Ensured model.data$ADJUSTED.Model rows with NA Protein are removed as before.

- DESCRIPTION
  - Bumped package Version from 1.17.0 → 1.17.1.
  - Tightened MSstatsPTM import constraint to MSstatsPTM (>= 2.12.0).

## Unit Tests

- inst/tinytest/test_groupComparisonLiP.R remains present and unchanged; tests exercise:
  - Error handling for missing inputs.
  - Silent handling when TrP is NULL.
  - Output structure and types for LiP.Model, TrP.Model, and Adjusted.LiP.Model (data.table).
  - Exact column-name expectations for the three result tables.
- Existing tests continue to validate backward compatibility of the refactor (no new tests were added or modified in this PR).

## Coding Guidelines Violations

- None detected in the changed files: changes are limited to refactoring an internal function call and metadata updates; no exported function signatures were altered and existing tests remain unmodified.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->